### PR TITLE
Refactor: Replace HTTP method assignment with more readable switch case

### DIFF
--- a/gohooks/GoHook.go
+++ b/gohooks/GoHook.go
@@ -79,6 +79,7 @@ func (hook *GoHook) Send(receiverURL string) (*http.Response, error) {
 	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
 		// Valid Methods, Do nothing
 	default:
+		// By default send GoHook using a POST method
 		hook.PreferredMethod = http.MethodPost
 	}
 

--- a/gohooks/GoHook.go
+++ b/gohooks/GoHook.go
@@ -75,11 +75,10 @@ func (hook *GoHook) Send(receiverURL string) (*http.Response, error) {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 	}
 
-	if hook.PreferredMethod == "" || (hook.PreferredMethod != http.MethodPost &&
-		hook.PreferredMethod != http.MethodPatch &&
-		hook.PreferredMethod != http.MethodPut &&
-		hook.PreferredMethod != http.MethodDelete) {
-		// By default send GoHook using a POST method
+	switch hook.PreferredMethod {
+	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+		// Valid Methods, Do nothing
+	default:
 		hook.PreferredMethod = http.MethodPost
 	}
 


### PR DESCRIPTION
Using a switch case makes code more readable :).